### PR TITLE
Not full return function (NEED UPDATE!!!)

### DIFF
--- a/menupy/__init__.py
+++ b/menupy/__init__.py
@@ -77,7 +77,7 @@ class OptionMenu(Menu):
 
         screen.refresh()
 
-    def add_option(self, option, color='white', bg_color='black'):
+    def add_option(self, option, ret='', color='white', bg_color='black'):
 
         """
             Add option to your OptionMenu object
@@ -90,7 +90,8 @@ class OptionMenu(Menu):
             :type bg_color: color
         """
 
-        self.menu_list.update({option: {'color': color,
+        self.menu_list.update({option: {'ret': ret,
+                                        'color': color,
                                         'bg_color': bg_color}})
 
     def _run(self, screen):
@@ -119,7 +120,9 @@ class OptionMenu(Menu):
             elif key == curses.KEY_ENTER or key in [10, 13]:
                 for index, (option, _) in enumerate(self.menu_list.items()):
                     if index == selected:
-                        return option
+                        return {option: keys['ret']
+                            for option, keys in self.menu_list.items()}
+
                 break
 
     def run(self):


### PR DESCRIPTION
You can use ret in add_option for return some names.
BUT!!!
Now it not working normally, returns string like that:
{'Option Selection #1': 'goge', 'Option Selection #2': 'aaa', 'Option Selection #3': 'test'}
where goge, aaa and , test is what given in:
NewMenu.add_option("Option Selection #2", color="red", ret="aaa")